### PR TITLE
[B2BSUITE-2] Fix organization request page 404 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Import `RequestOrganizationForm` component and re-declare store route to allow `/organization-request` storefront page to load
+
 ## [0.0.2] - 2022-02-23
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -13,21 +13,21 @@
     "vtex.b2b-checkout-settings": "1.x",
     "vtex.storefront-permissions-ui": "1.x",
     "vtex.admin-customers": "2.x",
-    "vtex.b2b-orders-history": "0.x"
+    "vtex.b2b-orders-history": "0.x",
+    "vtex.store": "2.x"
   },
   "builders": {
     "admin": "0.x",
     "docs": "0.x",
-    "react": "3.x"
+    "react": "3.x",
+    "store": "0.x"
   },
   "billingOptions": {
     "support": {
       "url": "https://help-tickets.vtex.com/en/support?app=vtex.b2b-suite"
     },
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/RequestOrganizationForm.tsx
+++ b/react/RequestOrganizationForm.tsx
@@ -1,0 +1,3 @@
+import { RequestOrganizationForm } from 'vtex.b2b-organizations'
+
+export default RequestOrganizationForm

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,0 +1,5 @@
+{
+  "store.organization-request": {
+    "blocks": ["request-organization"]
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,0 +1,8 @@
+{
+  "store.organization-request": {
+    "required": ["request-organization"]
+  },
+  "request-organization": {
+    "component": "RequestOrganizationForm"
+  }
+}

--- a/store/routes.json
+++ b/store/routes.json
@@ -1,0 +1,6 @@
+{
+  "store.organization-request": {
+    "title": "Organization Signup",
+    "path": "/organization-request"
+  }
+}


### PR DESCRIPTION
Previous version displayed a 404 page not found error when attempting to navigate to the Organization Request Form at the path `/organization-request`. The page would appear successfully if `vtex.b2b-organizations` was explicitly installed, but we want this suite app to function regardless of whether the dependency apps are directly installed or not. This PR fixes the problem by importing the Organization Request Form component from the `vtex.b2b-organizations` app and re-declaring the associated store route. 

New version linked here: https://b2bsuite--sandboxusdev.myvtex.com/organization-request