### PR TITLE
chore: major update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update dependency major version. If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
+    - vtex.b2b-admin-customers@2.x
+    - vtex.b2b-checkout-settings@3.x
+    - vtex.b2b-my-account@2.x
+    - vtex.b2b-orders-history@2.x
+    - vtex.b2b-organizations@3.x
+    - vtex.b2b-organizations-graphql@2.x
+    - vtex.b2b-quotes@3.x
+    - vtex.b2b-quotes-graphql@4.x
+    - vtex.b2b-suite@2.x
+    - vtex.b2b-theme@5.x
+    - vtex.storefront-permissions-components@2.x
+    - vtex.storefront-permissions-ui@1.x
+
 ## [1.0.0] - 2025-05-27
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -9,13 +9,13 @@
     "postreleasy": "vtex publish"
   },
   "dependencies": {
-    "vtex.b2b-admin-customers": "1.x",
-    "vtex.b2b-checkout-settings": "2.x",
-    "vtex.b2b-orders-history": "1.x",
-    "vtex.b2b-organizations": "2.x",
-    "vtex.b2b-quotes": "2.x",
+    "vtex.b2b-admin-customers": "2.x",
+    "vtex.b2b-checkout-settings": "3.x",
+    "vtex.b2b-orders-history": "2.x",
+    "vtex.b2b-organizations": "3.x",
+    "vtex.b2b-quotes": "3.x",
     "vtex.store": "2.x",
-    "vtex.storefront-permissions-ui": "2.x"
+    "vtex.storefront-permissions-ui": "3.x"
   },
   "builders": {
     "admin": "0.x",


### PR DESCRIPTION
**What problem is this solving?**

Generating new major version. This new version includes ACL feature. Now the following permissions are needed to view/edit organizations within the admin UI app:
`Buyer Organizations / buyer_organization_view`
`Buyer Organizations / buyer_organization_edit`

If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
    - vtex.b2b-admin-customers@2.x
    - vtex.b2b-checkout-settings@3.x
    - vtex.b2b-my-account@2.x
    - vtex.b2b-orders-history@2.x
    - vtex.b2b-organizations@3.x
    - vtex.b2b-organizations-graphql@2.x
    - vtex.b2b-quotes@3.x
    - vtex.b2b-quotes-graphql@4.x
    - vtex.b2b-suite@2.x
    - vtex.b2b-theme@5.x
    - vtex.storefront-permissions-components@2.x
    - vtex.storefront-permissions-ui@1.x